### PR TITLE
Remove daily_consumption water device class

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ The amount of water consumed during the last reported day.
 | Property | Value |
 |---|---|
 | **Unit** | L (liters) |
-| **Device class** | Water |
 | **State class** | Measurement |
 | **Icon** | mdi:water |
 

--- a/custom_components/eauidf/sensor.py
+++ b/custom_components/eauidf/sensor.py
@@ -46,7 +46,6 @@ SENSOR_TYPES: tuple[SedifSensorDescription, ...] = (
     SedifSensorDescription(
         key="daily_consumption",
         translation_key="daily_consumption",
-        device_class=SensorDeviceClass.WATER,
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfVolume.LITERS,
         icon="mdi:water",


### PR DESCRIPTION
Closes #9 by removing the WATER device class to the daily_consumption sensor since it is a measurement and the device class is not supporting this.