### PR TITLE
Add water cost statistic and exclude estimations from computation

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,13 +111,22 @@ The meter reading and daily consumption sensors expose the following additional 
 
 The integration imports historical water consumption data as **external statistics** with correct timestamps, so the Energy dashboard attributes usage to the right day (not when the integration polled).
 
-On first setup, up to **90 days** of history are imported. After that, only the last 7 days are fetched on each update cycle, keeping the statistics up to date without redundant API calls.
+On first setup, up to **90 days** of history are imported. After that, only the last 7 days are fetched on each update cycle, keeping the statistics up to date without redundant API calls. Estimated readings are excluded from statistics to avoid double-counting when the actual value is published later.
+
+Two external statistics are created per contract:
+
+| Statistic | Unit | Description |
+|---|---|---|
+| **SEDIF {contract_number} water consumption** | m³ | Cumulative water consumption (for Energy Dashboard water tracking) |
+| **SEDIF {contract_number} water cost** | EUR | Cumulative water cost based on the average price per m³ reported by the SEDIF portal |
 
 To add water tracking:
 
 1. Go to **Settings > Dashboards > Energy**
 2. In the **Water consumption** section, click **Add water source**
 3. Search for **SEDIF {contract_number} water consumption** — this is the external statistic created by the integration
+
+The water cost statistic can be used in custom cards or automations. It uses the average price per cubic meter provided by the SEDIF portal to compute daily costs.
 
 > **Important:** Use the external statistic, not the sensor entities. The **Meter Reading** sensor updates every 6 hours and timestamps data at poll time, which causes consumption to appear on the wrong day. The external statistic uses the actual date reported by SEDIF, so the Energy dashboard shows accurate daily breakdowns.
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ If installed via HACS, you can also uninstall the integration from HACS after re
 | **Email** | Yes | The email address used to log in to the SEDIF customer portal at [connexion.leaudiledefrance.fr](https://connexion.leaudiledefrance.fr). |
 | **Password** | Yes | The password for your SEDIF portal account. Stored locally in Home Assistant and only sent to the SEDIF portal for authentication. |
 
-Each contract appears as a separate device named **SEDIF Contract {number}** (e.g. "SEDIF Contract 9235380"), where the number matches your SEDIF contract reference.
+Each contract appears as a separate device named **SEDIF Contract {number}** (e.g. "SEDIF Contract XXXXXXX"), where the number matches your SEDIF contract reference.
 
 ## Entities
 

--- a/custom_components/eauidf/coordinator.py
+++ b/custom_components/eauidf/coordinator.py
@@ -225,6 +225,7 @@ class SedifCoordinator(DataUpdateCoordinator[SedifData]):
                 set(),
             )
         except HomeAssistantError:
+            _LOGGER.debug("No existing statistics for %s", statistic_id)
             last_stat = {}
         last_stats_time: float | None = None
         if last_stat:
@@ -292,6 +293,7 @@ class SedifCoordinator(DataUpdateCoordinator[SedifData]):
                 {"sum"},
             )
         except HomeAssistantError:
+            _LOGGER.debug("No existing cost statistics for %s", statistic_id)
             last_stat = {}
         if last_stat:
             raw_start = last_stat[statistic_id][0]["start"]

--- a/custom_components/eauidf/coordinator.py
+++ b/custom_components/eauidf/coordinator.py
@@ -18,7 +18,7 @@ from homeassistant.components.recorder.statistics import (
     get_last_statistics,
 )
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, UnitOfVolume
-from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.exceptions import ConfigEntryAuthFailed, HomeAssistantError
 from homeassistant.helpers.aiohttp_client import async_create_clientsession
 from homeassistant.helpers.issue_registry import (
     IssueSeverity,
@@ -122,16 +122,19 @@ class SedifCoordinator(DataUpdateCoordinator[SedifData]):
 
         for contract in contracts:
             statistic_id = f"{DOMAIN}:{contract['number']}_water_consumption"
-            last_stat: dict[str, list[dict[str, Any]]] = await get_instance(
-                self.hass
-            ).async_add_executor_job(
-                get_last_statistics,  # type: ignore[arg-type]
-                self.hass,
-                1,
-                statistic_id,
-                True,  # noqa: FBT003
-                set(),
-            )
+            try:
+                last_stat: dict[str, list[dict[str, Any]]] = await get_instance(
+                    self.hass
+                ).async_add_executor_job(
+                    get_last_statistics,  # type: ignore[arg-type]
+                    self.hass,
+                    1,
+                    statistic_id,
+                    True,  # noqa: FBT003
+                    set(),
+                )
+            except HomeAssistantError:
+                last_stat = {}
             if not last_stat:
                 _LOGGER.debug(
                     "No existing statistics for %s, importing %d days",
@@ -210,16 +213,19 @@ class SedifCoordinator(DataUpdateCoordinator[SedifData]):
             unit_of_measurement=UnitOfVolume.CUBIC_METERS,
         )
 
-        last_stat: dict[str, list[dict[str, Any]]] = await get_instance(
-            self.hass
-        ).async_add_executor_job(
-            get_last_statistics,  # type: ignore[arg-type]
-            self.hass,
-            1,
-            statistic_id,
-            True,  # noqa: FBT003
-            set(),
-        )
+        try:
+            last_stat: dict[str, list[dict[str, Any]]] = await get_instance(
+                self.hass
+            ).async_add_executor_job(
+                get_last_statistics,  # type: ignore[arg-type]
+                self.hass,
+                1,
+                statistic_id,
+                True,  # noqa: FBT003
+                set(),
+            )
+        except HomeAssistantError:
+            last_stat = {}
         last_stats_time: float | None = None
         if last_stat:
             raw_start = last_stat[statistic_id][0]["start"]
@@ -272,18 +278,21 @@ class SedifCoordinator(DataUpdateCoordinator[SedifData]):
             unit_of_measurement="EUR",
         )
 
-        last_stat: dict[str, list[dict[str, Any]]] = await get_instance(
-            self.hass
-        ).async_add_executor_job(
-            get_last_statistics,  # type: ignore[arg-type]
-            self.hass,
-            1,
-            statistic_id,
-            True,  # noqa: FBT003
-            {"sum"},
-        )
         last_stats_time: float | None = None
         running_sum: float = 0.0
+        try:
+            last_stat: dict[str, list[dict[str, Any]]] = await get_instance(
+                self.hass
+            ).async_add_executor_job(
+                get_last_statistics,  # type: ignore[arg-type]
+                self.hass,
+                1,
+                statistic_id,
+                True,  # noqa: FBT003
+                {"sum"},
+            )
+        except HomeAssistantError:
+            last_stat = {}
         if last_stat:
             raw_start = last_stat[statistic_id][0]["start"]
             if isinstance(raw_start, (int, float)):

--- a/custom_components/eauidf/coordinator.py
+++ b/custom_components/eauidf/coordinator.py
@@ -29,7 +29,12 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 from homeassistant.util import dt as dt_util
 from homeassistant.util.unit_conversion import VolumeConverter
 from pyeauidf import EauIDFClient
-from pyeauidf.client import AuthenticationError, ConsumptionRecord, EauIDFError
+from pyeauidf.client import (
+    AuthenticationError,
+    ConsumptionData,
+    ConsumptionRecord,
+    EauIDFError,
+)
 
 from .const import CONF_CONTRACTS, DOMAIN
 
@@ -56,7 +61,7 @@ class ContractData:
     is_estimated: bool
 
 
-type FetchResult = tuple[SedifData, dict[str, list[ConsumptionRecord]]]
+type FetchResult = tuple[SedifData, dict[str, ConsumptionData]]
 type SedifData = dict[str, ContractData]
 
 
@@ -88,9 +93,7 @@ class SedifCoordinator(DataUpdateCoordinator[SedifData]):
             username, password, session=async_create_clientsession(self.hass)
         )
         try:
-            sensor_data, all_records = await self._fetch_all(
-                client, contracts, start_date
-            )
+            sensor_data, all_data = await self._fetch_all(client, contracts, start_date)
         except AuthenticationError as err:
             self._on_failure()
             raise ConfigEntryAuthFailed(str(err)) from err
@@ -104,7 +107,7 @@ class SedifCoordinator(DataUpdateCoordinator[SedifData]):
             raise UpdateFailed(msg) from err
         else:
             self._on_success()
-            await self._insert_statistics(all_records)
+            await self._insert_statistics(all_data)
             return sensor_data
         finally:
             await client.close()
@@ -171,15 +174,22 @@ class SedifCoordinator(DataUpdateCoordinator[SedifData]):
 
     async def _insert_statistics(
         self,
-        records_by_contract: dict[str, list[ConsumptionRecord]],
+        data_by_contract: dict[str, ConsumptionData],
     ) -> None:
         """Import consumption records as external statistics."""
-        for contract_number, records in records_by_contract.items():
+        for contract_number, data in data_by_contract.items():
             try:
-                await self._insert_contract_statistics(contract_number, records)
+                await self._insert_contract_statistics(contract_number, data.records)
             except Exception:
                 _LOGGER.exception(
                     "Failed to insert statistics for contract %s",
+                    contract_number,
+                )
+            try:
+                await self._insert_cost_statistics(contract_number, data)
+            except Exception:
+                _LOGGER.exception(
+                    "Failed to insert cost statistics for contract %s",
                     contract_number,
                 )
 
@@ -221,6 +231,8 @@ class SedifCoordinator(DataUpdateCoordinator[SedifData]):
         local_tz = dt_util.get_default_time_zone()
         statistics: list[StatisticData] = []
         for record in sorted(records, key=lambda r: r.date):
+            if record.is_estimated:
+                continue
             d = record.date.date()
             start = datetime(d.year, d.month, d.day, tzinfo=local_tz)
             if last_stats_time is not None and start.timestamp() <= last_stats_time:
@@ -243,6 +255,72 @@ class SedifCoordinator(DataUpdateCoordinator[SedifData]):
         else:
             _LOGGER.debug("No new statistics to insert for %s", statistic_id)
 
+    async def _insert_cost_statistics(
+        self,
+        contract_number: str,
+        data: ConsumptionData,
+    ) -> None:
+        """Import cost statistics for a single contract."""
+        statistic_id = f"{DOMAIN}:{contract_number}_water_cost"
+        metadata = StatisticMetaData(
+            mean_type=StatisticMeanType.NONE,
+            has_sum=True,
+            name=f"SEDIF {contract_number} water cost",
+            source=DOMAIN,
+            statistic_id=statistic_id,
+            unit_class=None,
+            unit_of_measurement="EUR",
+        )
+
+        last_stat: dict[str, list[dict[str, Any]]] = await get_instance(
+            self.hass
+        ).async_add_executor_job(
+            get_last_statistics,  # type: ignore[arg-type]
+            self.hass,
+            1,
+            statistic_id,
+            True,  # noqa: FBT003
+            {"sum"},
+        )
+        last_stats_time: float | None = None
+        running_sum: float = 0.0
+        if last_stat:
+            raw_start = last_stat[statistic_id][0]["start"]
+            if isinstance(raw_start, (int, float)):
+                last_stats_time = raw_start
+            else:
+                last_stats_time = raw_start.timestamp()
+            running_sum = last_stat[statistic_id][0].get("sum", 0.0) or 0.0
+
+        local_tz = dt_util.get_default_time_zone()
+        statistics: list[StatisticData] = []
+        for record in sorted(data.records, key=lambda r: r.date):
+            if record.is_estimated:
+                continue
+            d = record.date.date()
+            start = datetime(d.year, d.month, d.day, tzinfo=local_tz)
+            if last_stats_time is not None and start.timestamp() <= last_stats_time:
+                continue
+            daily_cost = data.daily_cost(record)
+            running_sum += daily_cost
+            statistics.append(
+                StatisticData(
+                    start=start,
+                    state=daily_cost,
+                    sum=running_sum,
+                )
+            )
+
+        async_add_external_statistics(self.hass, metadata, statistics)
+        if statistics:
+            _LOGGER.debug(
+                "Inserted %d cost statistics for %s",
+                len(statistics),
+                statistic_id,
+            )
+        else:
+            _LOGGER.debug("No new cost statistics to insert for %s", statistic_id)
+
     @staticmethod
     async def _fetch_all(
         client: EauIDFClient,
@@ -252,18 +330,18 @@ class SedifCoordinator(DataUpdateCoordinator[SedifData]):
         """Fetch consumption data for all contracts."""
         await client.login()
         sensor_data: SedifData = {}
-        all_records: dict[str, list[ConsumptionRecord]] = {}
+        all_data: dict[str, ConsumptionData] = {}
         end = datetime.now(UTC).date()
         for contract in contracts:
             cid = contract["id"]
             number = contract["number"]
             try:
-                records = await client.get_daily_consumption(
+                data = await client.get_daily_consumption(
                     contract_id=cid, start_date=start_date, end_date=end
                 )
-                if records:
-                    all_records[number] = records
-                    latest = records[-1]
+                if data.records:
+                    all_data[number] = data
+                    latest = data.records[-1]
                     sensor_data[number] = ContractData(
                         meter_reading_m3=latest.meter_reading,
                         daily_consumption_l=latest.consumption_liters,
@@ -282,4 +360,4 @@ class SedifCoordinator(DataUpdateCoordinator[SedifData]):
         if not sensor_data and contracts:
             msg = "Failed to fetch data for any contract"
             raise EauIDFError(msg)
-        return sensor_data, all_records
+        return sensor_data, all_data

--- a/custom_components/eauidf/manifest.json
+++ b/custom_components/eauidf/manifest.json
@@ -8,6 +8,6 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/TimoPtr/ha_eauidf/issues",
   "quality_scale": "platinum",
-  "requirements": ["pyeauidf==1.0.1"],
+  "requirements": ["pyeauidf==1.2.0"],
   "version": "1.0.1"
 }

--- a/custom_components/eauidf/sensor.py
+++ b/custom_components/eauidf/sensor.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -22,6 +22,7 @@ PARALLEL_UPDATES = 0
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+    from datetime import date
 
     from homeassistant.core import HomeAssistant
     from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -33,7 +34,7 @@ if TYPE_CHECKING:
 class SedifSensorDescription(SensorEntityDescription):
     """Describe a SEDIF sensor."""
 
-    value_fn: Callable[[ContractData], Any]
+    value_fn: Callable[[ContractData], float | date]
     has_extra_attributes: bool = False
 
 
@@ -118,7 +119,7 @@ class SedifSensor(CoordinatorEntity[SedifCoordinator], SensorEntity):
         )
 
     @property
-    def native_value(self) -> Any:
+    def native_value(self) -> float | date | None:
         """Return the sensor value."""
         if not self.coordinator.data:
             return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "ha-eauidf"
 version = "1.0.1"
 requires-python = ">=3.14"
-dependencies = ["pyeauidf==1.0.0"]
+dependencies = ["pyeauidf==1.2.0"]
 
 [project.optional-dependencies]
 test = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,7 +27,7 @@ def mock_recorder_before_hass(recorder_db_url: str) -> None:
 MOCK_USERNAME = "test@example.com"
 MOCK_PASSWORD = "secret"
 MOCK_CONTRACT_ID = "CONTRACT_001"
-MOCK_CONTRACT_NUMBER = "9235380"
+MOCK_CONTRACT_NUMBER = "1234567"
 MOCK_CONTRACTS = [{"id": MOCK_CONTRACT_ID, "number": MOCK_CONTRACT_NUMBER}]
 MOCK_PRICE_PER_M3 = 4.5
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,7 @@ MOCK_PASSWORD = "secret"
 MOCK_CONTRACT_ID = "CONTRACT_001"
 MOCK_CONTRACT_NUMBER = "9235380"
 MOCK_CONTRACTS = [{"id": MOCK_CONTRACT_ID, "number": MOCK_CONTRACT_NUMBER}]
+MOCK_PRICE_PER_M3 = 4.5
 
 
 @pytest.fixture
@@ -74,6 +75,23 @@ def make_consumption_record(
     return record
 
 
+def make_consumption_data(
+    records: list[MagicMock], price_per_m3: float = MOCK_PRICE_PER_M3
+) -> MagicMock:
+    """Create a mock ConsumptionData with records and price."""
+    data = MagicMock()
+    data.records = records
+    data.price_per_m3 = price_per_m3
+    data.daily_cost = lambda record: (record.consumption_liters / 1000) * price_per_m3
+    return data
+
+
+@pytest.fixture
+def mock_consumption_data(mock_record: MagicMock) -> MagicMock:
+    """Single-record ConsumptionData mock."""
+    return make_consumption_data([mock_record])
+
+
 @pytest.fixture
 def mock_records_list() -> list[MagicMock]:
     base = date(2026, 5, 11)
@@ -82,3 +100,9 @@ def mock_records_list() -> list[MagicMock]:
         make_consumption_record(base + timedelta(days=1), 120.0, 1234.12),
         make_consumption_record(base + timedelta(days=2), 150.0, 1234.27),
     ]
+
+
+@pytest.fixture
+def mock_consumption_data_list(mock_records_list: list[MagicMock]) -> MagicMock:
+    """Multi-record ConsumptionData mock."""
+    return make_consumption_data(mock_records_list)

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -21,7 +21,11 @@ from custom_components.eauidf.coordinator import (
     ContractData,
     SedifCoordinator,
 )
-from tests.conftest import MOCK_CONTRACT_NUMBER
+from tests.conftest import (
+    MOCK_CONTRACT_NUMBER,
+    MOCK_PRICE_PER_M3,
+    make_consumption_data,
+)
 
 PATCH_CLIENT = "custom_components.eauidf.coordinator.EauIDFClient"
 
@@ -30,13 +34,13 @@ async def test_fetch_success(
     recorder_mock: Recorder,
     hass: HomeAssistant,
     mock_config_entry,
-    mock_record,
+    mock_consumption_data,
 ) -> None:
     mock_config_entry.add_to_hass(hass)
     client = MagicMock()
     client.login = AsyncMock()
     client.close = AsyncMock()
-    client.get_daily_consumption = AsyncMock(return_value=[mock_record])
+    client.get_daily_consumption = AsyncMock(return_value=mock_consumption_data)
 
     with patch(PATCH_CLIENT, return_value=client):
         coordinator = SedifCoordinator(hass, mock_config_entry)
@@ -45,10 +49,11 @@ async def test_fetch_success(
     assert MOCK_CONTRACT_NUMBER in coordinator.data
     data = coordinator.data[MOCK_CONTRACT_NUMBER]
     assert isinstance(data, ContractData)
-    assert data.meter_reading_m3 == mock_record.meter_reading
-    assert data.daily_consumption_l == mock_record.consumption_liters
-    assert data.last_date == mock_record.date.date()
-    assert data.is_estimated == mock_record.is_estimated
+    record = mock_consumption_data.records[0]
+    assert data.meter_reading_m3 == record.meter_reading
+    assert data.daily_consumption_l == record.consumption_liters
+    assert data.last_date == record.date.date()
+    assert data.is_estimated == record.is_estimated
 
 
 async def test_fetch_auth_error_raises(
@@ -107,7 +112,7 @@ async def test_fetch_empty_records_raises(
     client = MagicMock()
     client.login = AsyncMock()
     client.close = AsyncMock()
-    client.get_daily_consumption = AsyncMock(return_value=[])
+    client.get_daily_consumption = AsyncMock(return_value=make_consumption_data([]))
 
     with patch(PATCH_CLIENT, return_value=client):
         coordinator = SedifCoordinator(hass, mock_config_entry)
@@ -121,13 +126,13 @@ async def test_client_closed_on_success(
     recorder_mock: Recorder,
     hass: HomeAssistant,
     mock_config_entry,
-    mock_record,
+    mock_consumption_data,
 ) -> None:
     mock_config_entry.add_to_hass(hass)
     client = MagicMock()
     client.login = AsyncMock()
     client.close = AsyncMock()
-    client.get_daily_consumption = AsyncMock(return_value=[mock_record])
+    client.get_daily_consumption = AsyncMock(return_value=mock_consumption_data)
 
     with patch(PATCH_CLIENT, return_value=client):
         coordinator = SedifCoordinator(hass, mock_config_entry)
@@ -173,7 +178,7 @@ async def test_repair_issue_dismissed_on_success(
     recorder_mock: Recorder,
     hass: HomeAssistant,
     mock_config_entry,
-    mock_record,
+    mock_consumption_data,
 ) -> None:
     mock_config_entry.add_to_hass(hass)
     failing_client = MagicMock()
@@ -188,7 +193,7 @@ async def test_repair_issue_dismissed_on_success(
     success_client = MagicMock()
     success_client.login = AsyncMock()
     success_client.close = AsyncMock()
-    success_client.get_daily_consumption = AsyncMock(return_value=[mock_record])
+    success_client.get_daily_consumption = AsyncMock(return_value=mock_consumption_data)
 
     with patch(PATCH_CLIENT, return_value=success_client):
         await coordinator.async_refresh()
@@ -203,20 +208,21 @@ async def test_repair_issue_dismissed_on_success(
 # ---------------------------------------------------------------------------
 
 STAT_ID = f"{DOMAIN}:{MOCK_CONTRACT_NUMBER}_water_consumption"
+COST_STAT_ID = f"{DOMAIN}:{MOCK_CONTRACT_NUMBER}_water_cost"
 
 
 async def test_first_import_fetches_90_days(
     recorder_mock: Recorder,
     hass: HomeAssistant,
     mock_config_entry,
-    mock_records_list,
+    mock_consumption_data_list,
 ) -> None:
     """First import (no existing stats) should request 90 days of history."""
     mock_config_entry.add_to_hass(hass)
     client = MagicMock()
     client.login = AsyncMock()
     client.close = AsyncMock()
-    client.get_daily_consumption = AsyncMock(return_value=mock_records_list)
+    client.get_daily_consumption = AsyncMock(return_value=mock_consumption_data_list)
 
     with patch(PATCH_CLIENT, return_value=client):
         coordinator = SedifCoordinator(hass, mock_config_entry)
@@ -233,14 +239,14 @@ async def test_incremental_import_fetches_7_days(
     recorder_mock: Recorder,
     hass: HomeAssistant,
     mock_config_entry,
-    mock_records_list,
+    mock_consumption_data_list,
 ) -> None:
     """After first import, subsequent calls should use 7 days."""
     mock_config_entry.add_to_hass(hass)
     client = MagicMock()
     client.login = AsyncMock()
     client.close = AsyncMock()
-    client.get_daily_consumption = AsyncMock(return_value=mock_records_list)
+    client.get_daily_consumption = AsyncMock(return_value=mock_consumption_data_list)
 
     with patch(PATCH_CLIENT, return_value=client):
         coordinator = SedifCoordinator(hass, mock_config_entry)
@@ -260,14 +266,14 @@ async def test_statistics_values_correct(
     recorder_mock: Recorder,
     hass: HomeAssistant,
     mock_config_entry,
-    mock_records_list,
+    mock_consumption_data_list,
 ) -> None:
     """Verify sum=meter_reading and state=consumption_liters/1000."""
     mock_config_entry.add_to_hass(hass)
     client = MagicMock()
     client.login = AsyncMock()
     client.close = AsyncMock()
-    client.get_daily_consumption = AsyncMock(return_value=mock_records_list)
+    client.get_daily_consumption = AsyncMock(return_value=mock_consumption_data_list)
 
     with patch(PATCH_CLIENT, return_value=client):
         coordinator = SedifCoordinator(hass, mock_config_entry)
@@ -285,23 +291,62 @@ async def test_statistics_values_correct(
     )
     assert STAT_ID in stats
     last = stats[STAT_ID][0]
-    last_record = mock_records_list[-1]
+    last_record = mock_consumption_data_list.records[-1]
     assert last["sum"] == pytest.approx(last_record.meter_reading)
     assert last["state"] == pytest.approx(last_record.consumption_liters / 1000)
+
+
+async def test_cost_statistics_inserted(
+    recorder_mock: Recorder,
+    hass: HomeAssistant,
+    mock_config_entry,
+    mock_consumption_data_list,
+) -> None:
+    """Verify cost statistics are inserted with cumulative sum."""
+    mock_config_entry.add_to_hass(hass)
+    client = MagicMock()
+    client.login = AsyncMock()
+    client.close = AsyncMock()
+    client.get_daily_consumption = AsyncMock(return_value=mock_consumption_data_list)
+
+    with patch(PATCH_CLIENT, return_value=client):
+        coordinator = SedifCoordinator(hass, mock_config_entry)
+        await coordinator.async_refresh()
+
+    await hass.async_block_till_done()
+
+    stats = await hass.async_add_executor_job(
+        get_last_statistics,
+        hass,
+        1,
+        COST_STAT_ID,
+        True,  # noqa: FBT003
+        {"sum", "state"},
+    )
+    assert COST_STAT_ID in stats
+    last = stats[COST_STAT_ID][0]
+    records = mock_consumption_data_list.records
+    expected_sum = sum(
+        (r.consumption_liters / 1000) * MOCK_PRICE_PER_M3 for r in records
+    )
+    assert last["sum"] == pytest.approx(expected_sum)
+    last_record = records[-1]
+    expected_state = (last_record.consumption_liters / 1000) * MOCK_PRICE_PER_M3
+    assert last["state"] == pytest.approx(expected_state)
 
 
 async def test_statistics_failure_does_not_break_sensors(
     recorder_mock: Recorder,
     hass: HomeAssistant,
     mock_config_entry,
-    mock_records_list,
+    mock_consumption_data_list,
 ) -> None:
     """If statistics insertion fails, sensor data should still be available."""
     mock_config_entry.add_to_hass(hass)
     client = MagicMock()
     client.login = AsyncMock()
     client.close = AsyncMock()
-    client.get_daily_consumption = AsyncMock(return_value=mock_records_list)
+    client.get_daily_consumption = AsyncMock(return_value=mock_consumption_data_list)
 
     with (
         patch(PATCH_CLIENT, return_value=client),

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -280,6 +280,7 @@ async def test_statistics_values_correct(
         await coordinator.async_refresh()
 
     await hass.async_block_till_done()
+    await recorder_mock.async_block_till_done()
 
     stats = await hass.async_add_executor_job(
         get_last_statistics,
@@ -314,6 +315,7 @@ async def test_cost_statistics_inserted(
         await coordinator.async_refresh()
 
     await hass.async_block_till_done()
+    await recorder_mock.async_block_till_done()
 
     stats = await hass.async_add_executor_job(
         get_last_statistics,

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -27,7 +27,7 @@ async def test_diagnostics_redacts_credentials(
     init_client.login = AsyncMock()
     init_client.get_contracts = AsyncMock(return_value=[MOCK_CONTRACT_ID])
     init_client.get_contract_details = AsyncMock(
-        return_value={"contrat": {"Name": "9235380"}}
+        return_value={"contrat": {"Name": MOCK_CONTRACT_NUMBER}}
     )
 
     coord_client = MagicMock()

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -11,6 +11,7 @@ from tests.conftest import (
     MOCK_CONTRACT_NUMBER,
     MOCK_PASSWORD,
     MOCK_USERNAME,
+    make_consumption_data,
 )
 
 PATCH_INIT_CLIENT = "custom_components.eauidf.EauIDFClient"
@@ -32,7 +33,9 @@ async def test_diagnostics_redacts_credentials(
     coord_client = MagicMock()
     coord_client.login = AsyncMock()
     coord_client.close = AsyncMock()
-    coord_client.get_daily_consumption = AsyncMock(return_value=[mock_record])
+    coord_client.get_daily_consumption = AsyncMock(
+        return_value=make_consumption_data([mock_record])
+    )
 
     with (
         patch(PATCH_INIT_CLIENT, return_value=init_client),

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -12,6 +12,7 @@ from custom_components.eauidf.const import DOMAIN
 from tests.conftest import (
     MOCK_CONTRACT_NUMBER,
     MOCK_CONTRACTS,
+    make_consumption_data,
 )
 
 PATCH_INIT_CLIENT = "custom_components.eauidf.EauIDFClient"
@@ -34,7 +35,9 @@ def _make_coord_client(mock_record: MagicMock) -> MagicMock:
     client = MagicMock()
     client.login = AsyncMock()
     client.close = AsyncMock()
-    client.get_daily_consumption = AsyncMock(return_value=[mock_record])
+    client.get_daily_consumption = AsyncMock(
+        return_value=make_consumption_data([mock_record])
+    )
     return client
 
 


### PR DESCRIPTION
The statistics were including the estimation reported by the API but we shouldn't since it's cumulative and would combine the estimate and the real value retrieved a bit later.

This PR also bump to 1.2.0 pyeauidf and expose the water cost statistics that can be attached to the water consumption in the energy dashboard.