### PR TITLE
Back meter_reading sensor with latest confirmed reading (#26)

### DIFF
--- a/custom_components/eauidf/coordinator.py
+++ b/custom_components/eauidf/coordinator.py
@@ -352,7 +352,18 @@ class SedifCoordinator(DataUpdateCoordinator[SedifData]):
                 )
                 if data.records:
                     all_data[number] = data
-                    latest = data.records[-1]
+                    # SEDIF revises estimated readings, sometimes downward to a
+                    # lower real value. The meter_reading sensor is
+                    # total_increasing, so back it with the latest *confirmed*
+                    # reading to stay monotonic (matching the statistics import,
+                    # which also skips estimated records). Fall back to the
+                    # latest record overall when nothing is confirmed yet.
+                    # See TimoPtr/ha_eauidf#26.
+                    confirmed = [r for r in data.records if not r.is_estimated]
+                    latest = max(
+                        confirmed or data.records,
+                        key=lambda r: r.date,
+                    )
                     sensor_data[number] = ContractData(
                         meter_reading_m3=latest.meter_reading,
                         daily_consumption_l=latest.consumption_liters,

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,6 +1,6 @@
 """Tests for the coordinator."""
 
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -25,6 +25,7 @@ from tests.conftest import (
     MOCK_CONTRACT_NUMBER,
     MOCK_PRICE_PER_M3,
     make_consumption_data,
+    make_consumption_record,
 )
 
 PATCH_CLIENT = "custom_components.eauidf.coordinator.EauIDFClient"
@@ -54,6 +55,71 @@ async def test_fetch_success(
     assert data.daily_consumption_l == record.consumption_liters
     assert data.last_date == record.date.date()
     assert data.is_estimated == record.is_estimated
+
+
+async def test_fetch_uses_latest_confirmed_reading(
+    recorder_mock: Recorder,
+    hass: HomeAssistant,
+    mock_config_entry,
+) -> None:
+    """Sensor state should reflect the latest non-estimated reading.
+
+    SEDIF can revise an estimated reading downward to a lower real value.
+    Because meter_reading is total_increasing, tracking the estimated tail
+    makes the sensor decrease. See TimoPtr/ha_eauidf#26.
+    """
+    confirmed_old = make_consumption_record(date(2026, 6, 28), 250.0, 105.800)
+    confirmed = make_consumption_record(date(2026, 6, 29), 265.0, 105.900)
+    estimated = make_consumption_record(date(2026, 6, 30), 240.0, 105.927)
+    estimated.is_estimated = True
+    # Chronological order, latest record estimated: the realistic SEDIF case.
+    # The earlier confirmed record proves selection picks the latest by date,
+    # not merely the first non-estimated record.
+    data = make_consumption_data([confirmed_old, confirmed, estimated])
+
+    mock_config_entry.add_to_hass(hass)
+    client = MagicMock()
+    client.login = AsyncMock()
+    client.close = AsyncMock()
+    client.get_daily_consumption = AsyncMock(return_value=data)
+
+    with patch(PATCH_CLIENT, return_value=client):
+        coordinator = SedifCoordinator(hass, mock_config_entry)
+        await coordinator.async_refresh()
+
+    result = coordinator.data[MOCK_CONTRACT_NUMBER]
+    assert result.meter_reading_m3 == confirmed.meter_reading
+    assert result.daily_consumption_l == confirmed.consumption_liters
+    assert result.last_date == confirmed.date.date()
+    assert result.is_estimated is False
+
+
+async def test_fetch_falls_back_to_latest_when_all_estimated(
+    recorder_mock: Recorder,
+    hass: HomeAssistant,
+    mock_config_entry,
+) -> None:
+    """When every record is estimated, fall back to the latest one by date."""
+    older = make_consumption_record(date(2026, 6, 29), 265.0, 105.900)
+    older.is_estimated = True
+    newer = make_consumption_record(date(2026, 6, 30), 240.0, 105.927)
+    newer.is_estimated = True
+    data = make_consumption_data([older, newer])
+
+    mock_config_entry.add_to_hass(hass)
+    client = MagicMock()
+    client.login = AsyncMock()
+    client.close = AsyncMock()
+    client.get_daily_consumption = AsyncMock(return_value=data)
+
+    with patch(PATCH_CLIENT, return_value=client):
+        coordinator = SedifCoordinator(hass, mock_config_entry)
+        await coordinator.async_refresh()
+
+    result = coordinator.data[MOCK_CONTRACT_NUMBER]
+    assert result.meter_reading_m3 == newer.meter_reading
+    assert result.last_date == newer.date.date()
+    assert result.is_estimated is True
 
 
 async def test_fetch_auth_error_raises(


### PR DESCRIPTION
Fixes #26

## Problem

The `meter_reading` sensor (`sensor.sedif_contract_<id>_releve_compteur`) is declared `SensorStateClass.TOTAL_INCREASING`, but its value came from `data.records[-1]` unconditionally. SEDIF first returns an **estimated** reading for the most recent day (often over-valued) and later replaces it with the **real** reading, which can be lower. The sensor therefore decreased between fetch cycles, causing:

- HA warning `state is not strictly increasing`
- A negative hourly `change` (−0.023 m³ in the report)
- A **negative bar** in the Energy dashboard water block

## Fix

Back the sensor with the latest **confirmed** (non-estimated) record instead of the latest record overall, falling back to the latest record only when nothing is confirmed yet:

```python
confirmed = [r for r in data.records if not r.is_estimated]
latest = max(confirmed or data.records, key=lambda r: r.date)
```

This mirrors the statistics import, which already skips estimated records (`_insert_contract_statistics`), and keeps the `total_increasing` sensor monotonic. It's option 1 from the issue (the reporter's preferred one) — real meter readings are physically monotonic, so a legitimate downward correction of a *real* value is not expected.

### Behavioral note

`daily_consumption` and `last_reading_date` now also reflect the latest **confirmed** day, so they lag slightly until SEDIF confirms the reading, rather than surfacing provisional estimated values. `is_estimated` remains exposed as an attribute and is `true` only in the all-estimated fallback case.

## Tests

Added to `tests/test_coordinator.py` (TDD, confirmed RED → GREEN):

- `test_fetch_uses_latest_confirmed_reading` — latest record estimated + a lower earlier real value; asserts the sensor uses the latest confirmed reading (selected by date, not list position).
- `test_fetch_falls_back_to_latest_when_all_estimated` — every record estimated; asserts fallback to the latest by date.

## Verification

Python 3.14 (matching CI):

- ✅ `pytest tests/` — 40 passed
- ✅ `ruff check .`
- ✅ `ruff format --check .`
- ✅ `mypy custom_components/eauidf/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)